### PR TITLE
Fixes Integer Sizes That Produced Build Warnings

### DIFF
--- a/include/tinf.h
+++ b/include/tinf.h
@@ -78,7 +78,7 @@ void TINFCC tinf_init(void);
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-uint32_t TINFCC tinf_uncompress(void *dest, uint32_t *destLen,
+int32_t TINFCC tinf_uncompress(void *dest, uint32_t *destLen,
                            const void *source, uint32_t sourceLen);
 
 /**
@@ -96,7 +96,7 @@ uint32_t TINFCC tinf_uncompress(void *dest, uint32_t *destLen,
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-uint32_t TINFCC tinf_gzip_uncompress(void *dest, uint32_t *destLen,
+int32_t TINFCC tinf_gzip_uncompress(void *dest, uint32_t *destLen,
                                 const void *source, uint32_t sourceLen);
 
 /**
@@ -114,7 +114,7 @@ uint32_t TINFCC tinf_gzip_uncompress(void *dest, uint32_t *destLen,
  * @param sourceLen size of compressed data
  * @return `TINF_OK` on success, error code on error
  */
-uint32_t TINFCC tinf_zlib_uncompress(void *dest, uint32_t *destLen,
+int32_t TINFCC tinf_zlib_uncompress(void *dest, uint32_t *destLen,
                                 const void *source, uint32_t sourceLen);
 
 /**

--- a/src/adler32.c
+++ b/src/adler32.c
@@ -41,8 +41,8 @@ uint32_t tinf_adler32(const void *data, uint32_t length)
     uint32_t s2 = 0;
 
     while (length > 0) {
-        uint32_t k = length < A32_NMAX ? length : A32_NMAX;
-        uint32_t i;
+        int32_t k = length < A32_NMAX ? length : A32_NMAX;
+        int32_t i;
 
         for (i = k / 16; i; --i, buf += 16) {
             s1 += buf[0];

--- a/src/tinfgzip.c
+++ b/src/tinfgzip.c
@@ -47,14 +47,14 @@ static uint32_t read_le32(const unsigned char *p)
          | ((uint32_t) p[3] << 24);
 }
 
-uint32_t tinf_gzip_uncompress(void *dest, uint32_t *destLen,
+int32_t tinf_gzip_uncompress(void *dest, uint32_t *destLen,
                          const void *source, uint32_t sourceLen)
 {
     const unsigned char *src = (const unsigned char *) source;
     unsigned char *dst = (unsigned char *) dest;
     const unsigned char *start;
     uint32_t dlen, crc32;
-    uint32_t res;
+    int32_t res;
     unsigned char flg;
 
     /* -- Check header -- */

--- a/src/tinfzlib.c
+++ b/src/tinfzlib.c
@@ -33,13 +33,13 @@ static uint32_t read_be32(const unsigned char *p)
          | ((uint32_t) p[3]);
 }
 
-uint32_t tinf_zlib_uncompress(void *dest, uint32_t *destLen,
+int32_t tinf_zlib_uncompress(void *dest, uint32_t *destLen,
                          const void *source, uint32_t sourceLen)
 {
     const unsigned char *src = (const unsigned char *) source;
     unsigned char *dst = (unsigned char *) dest;
     uint32_t a32;
-    uint32_t res;
+    int32_t res;
     unsigned char cmf, flg;
 
     /* -- Check header -- */

--- a/test/greatest.h
+++ b/test/greatest.h
@@ -650,8 +650,8 @@ typedef enum greatest_test_res {
     }
 
 #define GREATEST_CLOCK_DIFF(C1, C2)                                     \
-    GREATEST_FPRINTF(GREATEST_STDOUT, " (%lu ticks, %.3f sec)",         \
-        (uint32_t unsigned int) (C2) - (uint32_t unsigned int)(C1),             \
+    GREATEST_FPRINTF(GREATEST_STDOUT, " (%u ticks, %.3f sec)",          \
+        (uint32_t) (C2) - (uint32_t)(C1),                               \
         (double)((C2) - (C1)) / (1.0 * (double)CLOCKS_PER_SEC))
 #else
 #define GREATEST_SET_TIME(UNUSED)
@@ -1116,7 +1116,7 @@ int greatest_prng_init_second_pass(int id, uint32_t seed) {        \
     p->a = (p->a ? p->a : 4) | 1;            /* multiplied by 4 */      \
     p->c = 2147483647;        /* and so p->c ((2 ** 31) - 1) is */      \
     p->initialized = 1;     /* always relatively prime to p->a. */      \
-    fprintf(stderr, "init_second_pass: a %lu, c %lu, state %lu\n",      \
+    fprintf(stderr, "init_second_pass: a %u, c %u, state %u\n",         \
         p->a, p->c, p->state);                                          \
     return 1;                                                           \
 }                                                                       \


### PR DESCRIPTION
Those mistakes were introduced in 15080f1afcfa2710be72206d6a10aa6af8cfd875.

Tests also didn't build.